### PR TITLE
remove useless function in class

### DIFF
--- a/src/scrap/Investigador.ts
+++ b/src/scrap/Investigador.ts
@@ -43,7 +43,7 @@ export class Investigador implements IInvestigador {
          
     }
     async closeBrowser(): Promise<any> {
-        await this.getBrowser()?.close()
+        await this.browser?.close()
     }
 
 }


### PR DESCRIPTION
You can call directly "this.browser" without using a getter method.